### PR TITLE
Missing a Dependency for Vim

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,7 @@ version          "0.1.0"
 
 supports "ubuntu"
 
+depends "apt",         "~> 2.0"
 depends "ark",         "~> 0.0"
 depends "fasd",        "~> 1.0"
 depends "memcached",   "~> 2.0"

--- a/recipes/_vim.rb
+++ b/recipes/_vim.rb
@@ -27,6 +27,8 @@
 version    = node.attr!("swpr_dev", "vim", "version")
 source_url = "https://github.com/b4winckler/vim/archive/v#{version}.tar.gz"
 
+package "libgmp-dev"
+
 ark "vim" do
   url source_url
   version version

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,6 +24,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+include_recipe "apt"
+
 include_recipe "swpr_dev::_hub"
 include_recipe "swpr_dev::_nginx"
 include_recipe "swpr_dev::_shell"

--- a/test/unit/recipes/_vim_spec.rb
+++ b/test/unit/recipes/_vim_spec.rb
@@ -38,6 +38,10 @@ describe "swpr_dev::_vim" do
     expect { chef_run }.to_not raise_error
   end
 
+  it "installs prerequisite packages" do
+    expect(chef_run).to install_package("libgmp-dev")
+  end
+
   it "arks and installs vim with make" do
     expect(chef_run).to install_with_make_ark("vim").with(
       url: "https://github.com/b4winckler/vim/archive/v7-4-658.tar.gz",

--- a/test/unit/recipes/default_spec.rb
+++ b/test/unit/recipes/default_spec.rb
@@ -26,6 +26,7 @@
 
 describe "swpr_dev::default" do
   PRIVATE_RECIPES = %w(_hub _nginx _shell _tmux _vim).freeze
+  PUBLIC_RECIPES  = %w(apt fasd memcached redisio redisio::enable).freeze
 
   cached(:chef_run) do
     runner = ChefSpec::SoloRunner.new
@@ -39,6 +40,12 @@ describe "swpr_dev::default" do
   PRIVATE_RECIPES.each do |recipe|
     it "includes the #{recipe} recipe" do
       expect(chef_run).to include_recipe("swpr_dev::#{recipe}")
+    end
+  end
+
+  PUBLIC_RECIPES.each do |recipe|
+    it "includes the #{recipe} recipe" do
+      expect(chef_run).to include_recipe(recipe)
     end
   end
 


### PR DESCRIPTION
# The Problem

Some provisions (depending on what's included before this cookbook) will require `libgmp-dev` in order to compile vim.
# The Solution

Uh...adding libgmp-dev
